### PR TITLE
Add ITestOutputHelper test messages to the test spans

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -28,7 +28,7 @@ class Build : NukeBuild
     [Parameter("Where the NuGet package should be published")]
     readonly AbsolutePath ArtifactsDirectory = RootDirectory / "artifacts";
 
-    [Parameter] public string Version = "0.0.26"; 
+    [Parameter] public string Version = "0.0.27"; 
 
     Target Clean => _ => _
         .Executes(() =>

--- a/src/Samples/XunitSample/UnitTest1.cs
+++ b/src/Samples/XunitSample/UnitTest1.cs
@@ -1,30 +1,44 @@
+using Xunit.Abstractions;
+
 namespace XunitSample;
 
 public class UnitTest1
 {
+    private ITestOutputHelper _output;
+
+    public UnitTest1(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     [Fact]
     public void Test1()
     {
+        _output.WriteLine("Test 1 message");
     }
 
     [Fact]
     public void Test2()
     {
+        _output.WriteLine("Test 2 message");
     }
 
     [Fact]
     public void Test3()
     {
+        _output.WriteLine("Test 3 message");
     }
 
     [Fact]
     public void Test4()
     {
+        _output.WriteLine("Test 4 message");
     }
 
     [Fact]
     public void Test5()
     {
+        _output.WriteLine("Test 5 message");
         var k = 0;
         var y = 18;
         var z = y / k;


### PR DESCRIPTION
This PR adds support to include `ITestOutputHelper` messages as logs in the test span. 

Example:

![image](https://user-images.githubusercontent.com/69803/200039586-5666baf2-e3de-4110-9159-4c8757af1cea.png)
