### PR TITLE
Better exception type extractor

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -28,7 +28,7 @@ class Build : NukeBuild
     [Parameter("Where the NuGet package should be published")]
     readonly AbsolutePath ArtifactsDirectory = RootDirectory / "artifacts";
 
-    [Parameter] public string Version = "0.0.28"; 
+    [Parameter] public string Version = "0.0.29"; 
 
     Target Clean => _ => _
         .Executes(() =>

--- a/src/DatadogTestLogger/TestSuiteSerializer.cs
+++ b/src/DatadogTestLogger/TestSuiteSerializer.cs
@@ -401,7 +401,23 @@ internal class TestSuiteSerializer
                                     errorMessage = errorMessage.Substring(sepIndex + 1).Trim();
                                 }
                             }
-                            
+
+                            // If we couldn't extract the type we try further (more allocations)
+                            if (errorType == "Exception")
+                            {
+                                foreach (var errorMessagePart in errorMessage.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries))
+                                {
+                                    var phrase = errorMessagePart.Trim();
+
+                                    if (phrase.EndsWith("Exception"))
+                                    {
+                                        var spaceIndex = phrase.IndexOf(" ", StringComparison.Ordinal);
+                                        errorType = phrase.Substring(spaceIndex + 1);
+                                        break;
+                                    }
+                                }
+                            }
+
                             output.AppendLine("    Closing test: " + testName +
                                               $" [FAIL] [{duration}, {errorType}, {errorMessage}]");
                             test.SetErrorInfo(errorType, errorMessage, result.ErrorStackTrace);


### PR DESCRIPTION
This PR tries to improve the discovery of the ExceptionType in some cases, like this one:
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/69803/201684855-5daf38df-529e-4140-a126-4d7603f57674.png">

Currently the type is marked as `Exception` but we want to extract `System.Net.WebException`