### PR TITLE
Bump version of Microsoft.TestPlatform.ObjectModel to 17.3.2

### DIFF
--- a/src/DatadogTestLogger/DatadogTestLogger.csproj
+++ b/src/DatadogTestLogger/DatadogTestLogger.csproj
@@ -88,7 +88,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.9.1" />
+        <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" />
         <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Can't go higher, because they dropped support for net461