### PR TITLE
Add test.final_status tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Datadog Test Logger is a .NET custom test logger and in-process data collector for .NET test frameworks (xUnit, NUnit, MSTest). It serializes test results and ships them to Datadog using vendored Datadog.Trace libraries. Published as a NuGet package.
+
+## Build Commands
+
+The project uses **Nuke** (C# build automation). The default target is `Pack` which runs: Restore → Compile → Test → Pack.
+
+```bash
+# Full build + test + NuGet pack (default pipeline)
+./build.sh
+
+# Run only tests (via dotnet directly)
+dotnet test test/DatadogTestLogger.Test/DatadogTestLogger.Test.csproj -c Release
+
+# Run a single test
+dotnet test test/DatadogTestLogger.Test/DatadogTestLogger.Test.csproj -c Release --filter "FullyQualifiedName~TestMethodName"
+
+# Build only
+dotnet build -c Release
+
+# Update vendored Datadog.Trace code
+./build.sh --target VendorDatadogTrace
+```
+
+Requires .NET 7.0 SDK. `global.json` has `allowPrerelease: true`.
+
+## Architecture
+
+### Two main libraries
+
+**DatadogTestLogger** (`src/DatadogTestLogger/`): The test logger.
+- `DatadogTestLogger.cs` — Entry point, extends `Spekt.TestLogger.TestLogger`, registered via `[FriendlyName("datadog")]`
+- `DatadogTestResultSerializer.cs` — Implements `ITestResultSerializer`, orchestrates serialization, validates `DD_API_KEY`, writes results to timestamped files
+- `TestSuiteSerializer.cs` — Core logic: resolves test types/methods via reflection from assemblies, handles nested types and inheritance, uses vendored Datadog.Trace for CI metadata and direct submission
+- `DatadogEnvironmentVariablesReplacer.cs` — IDisposable context manager that temporarily replaces `DD_*` env vars
+
+**DatadogCollector** (`src/DatadogCollector/`): In-process data collector.
+- `DatadogInProcCollector.cs` — Extends `InProcDataCollection`, delegates to specialized collectors
+- `CpuInProcDataCollection.cs` — Tracks CPU usage per test case
+- `DatadogCoverageCollector.cs` — Code coverage collection (uses vendored Mono.Cecil)
+- `Configuration.cs` — Singleton (Lazy<T>), reads `DD_COLLECTOR_CPU_USAGE` (default: on) and `DD_COLLECTOR_COVERAGE` (default: off)
+
+### Vendored dependencies
+
+Both libraries vendor code from Datadog.Trace into `Vendors/` directories. These are updated via the `VendorDatadogTrace` Nuke target. Do not edit vendored files directly.
+
+### Multi-targeting
+
+Both libraries target: net7.0, net6.0, net5.0, netcoreapp3.1/3.0/2.2/2.1, net48, net472, net462. The csproj files define many conditional compilation symbols for framework-specific behavior. `AllowUnsafeBlocks` is enabled. Fody/ILMerge is used for assembly merging.
+
+### Tests
+
+- Unit tests in `test/DatadogTestLogger.Test/` use xUnit
+- Sample projects in `src/Samples/` (XunitSample, MSTestSample, NUnitSample) demonstrate real usage
+
+## Key Environment Variables
+
+All Datadog variables use `DD_` prefix. Logger-specific ones use `DD_LOGGER_` prefix.
+- `DD_API_KEY` — Required for submission
+- `DD_COLLECTOR_CPU_USAGE` — Enable/disable CPU tracking (default: enabled)
+- `DD_COLLECTOR_COVERAGE` — Enable/disable coverage (default: disabled)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -28,7 +28,7 @@ class Build : NukeBuild
     [Parameter("Where the NuGet package should be published")]
     readonly AbsolutePath ArtifactsDirectory = RootDirectory / "artifacts";
 
-    [Parameter] public string Version = "0.0.52"; 
+    [Parameter] public string Version = "0.0.53"; 
 
     Target Clean => _ => _
         .Executes(() =>

--- a/src/DatadogTestLogger/TestSuiteSerializer.cs
+++ b/src/DatadogTestLogger/TestSuiteSerializer.cs
@@ -19,7 +19,18 @@ namespace DatadogTestLogger;
 
 internal class TestSuiteSerializer
 {
+    private const string TestFinalStatusTag = "test.final_status";
     private readonly TestRunConfiguration _runConfiguration;
+
+    private static void SetFinalStatus(Test test, TestStatus status)
+    {
+        test.SetTag(TestFinalStatusTag, status switch
+        {
+            TestStatus.Pass => "pass",
+            TestStatus.Fail => "fail",
+            _ => "skip",
+        });
+    }
 
     public TestSuiteSerializer(TestRunConfiguration runConfiguration)
     {
@@ -598,6 +609,7 @@ internal class TestSuiteSerializer
                             if (result.Outcome == TestOutcome.Passed)
                             {
                                 output.AppendLine("    Closing test: " + testName + $" [PASS] [{duration}]");
+                                SetFinalStatus(test, TestStatus.Pass);
                                 test.Close(TestStatus.Pass, duration);
                             }
                             else if (result.Outcome == TestOutcome.Skipped)
@@ -608,12 +620,14 @@ internal class TestSuiteSerializer
                                 {
                                     output.AppendLine("    Closing test: " + testName +
                                                       $" [SKIP] [{duration}, {xUnitSkipMessage.Text}]");
+                                    SetFinalStatus(test, TestStatus.Skip);
                                     test.Close(TestStatus.Skip, duration, xUnitSkipMessage.Text);
                                 }
                                 else
                                 {
                                     output.AppendLine("    Closing test: " + testName +
                                                       $" [SKIP] [{duration}, {result.ErrorMessage}]");
+                                    SetFinalStatus(test, TestStatus.Skip);
                                     test.Close(TestStatus.Skip, duration, result.ErrorMessage);
                                 }
                             }
@@ -655,12 +669,14 @@ internal class TestSuiteSerializer
                                 output.AppendLine("    Closing test: " + testName +
                                                   $" [FAIL] [{duration}, {errorType}, {errorMessage}]");
                                 test.SetErrorInfo(errorType, errorMessage, result.ErrorStackTrace);
+                                SetFinalStatus(test, TestStatus.Fail);
                                 test.Close(TestStatus.Fail, duration);
                             }
                             else
                             {
                                 output.AppendLine("    Closing test: " + testName +
                                                   $" [SKIP/NONE] [{duration}, {result.ErrorMessage}]");
+                                SetFinalStatus(test, TestStatus.Skip);
                                 test.Close(TestStatus.Skip, duration, result.ErrorMessage);
                             }
                         }


### PR DESCRIPTION
## Summary

- Adds a `test.final_status` tag to every test span, emitted via `test.SetTag()` before each `test.Close()` call in `TestSuiteSerializer.cs`
- This tag is requested by Datadog to compute health SLIs and notify test owners on main/master failures (reported as `dd_tags[test.final_status]`)
- Since this logger is passive and doesn't alter test behavior, `test.final_status` always mirrors `test.status` (pass/fail/skip)
- Tag name is defined as a `const` with a `SetFinalStatus` helper that maps `TestStatus` enum values to lowercase strings
- Bumps version from 0.0.52 to 0.0.53

## Files changed

- `src/DatadogTestLogger/TestSuiteSerializer.cs` — new const, helper method, and 5 `SetFinalStatus()` calls (pass, fail, skip x3)
- `build/Build.cs` — version bump to 0.0.53

## Test plan

- [x] `dotnet build -c Release` compiles across all target frameworks (0 errors)
- [x] `dotnet test` — all 21 unit tests pass
- [x] Full Nuke pipeline (`./build.sh`): Restore, Compile, Test, Pack all succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)