### PR TITLE
Port newer codeowners from current

### DIFF
--- a/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -602,7 +602,7 @@ namespace DatadogTestLogger.Vendors.Datadog.Trace.Ci
                     if (File.Exists(codeOwnersPath))
                     {
                         Log.Debug("CODEOWNERS file found: {Path}", codeOwnersPath);
-                        CodeOwners = new CodeOwners(codeOwnersPath);
+                        CodeOwners = new CodeOwners(codeOwnersPath, Provider == "gitlab" ? CodeOwners.Platform.GitLab : CodeOwners.Platform.GitHub);
                         break;
                     }
                 }

--- a/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/CodeOwners.cs
+++ b/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/CodeOwners.cs
@@ -7,203 +7,329 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using DatadogTestLogger.Vendors.Datadog.Trace.Util;
+using System.Text.RegularExpressions;
 
 namespace DatadogTestLogger.Vendors.Datadog.Trace.Ci
 {
-    internal class CodeOwners
+    /// <summary>
+    /// A feature‑complete, allocation‑conscious CODEOWNERS parser that supports both GitHub and GitLab
+    /// semantics (sections, exclusions, optional sections, approval counts, role owners, globstar, etc.).
+    /// Usage:
+    ///   var owners = new CodeOwners(pathToFile, CodeOwners.Platform.GitLab).Match("src/app/Program.cs");
+    ///   // owners is an IEnumerable{string} of unique owners that apply to that file.
+    /// </summary>
+    internal sealed class CodeOwners
     {
-        private readonly IGrouping<string, Entry>[] _sections;
+        private readonly IReadOnlyList<Section> _sections;
+        private readonly Platform _platform;
 
-        public CodeOwners(string filePath)
+        public CodeOwners(string filePath, Platform platform)
         {
             if (string.IsNullOrEmpty(filePath))
             {
-                ThrowHelper.ThrowArgumentNullException(nameof(filePath));
+                throw new ArgumentNullException(nameof(filePath));
             }
 
-            var entriesList = new List<Entry>();
-            var lines = File.ReadAllLines(filePath);
-            var sectionsList = new List<string>();
-            string currentSectionName = null;
+            _platform = platform;
+            _sections = Parse(File.ReadLines(filePath), platform);
+        }
+
+        /// <summary>
+        /// Returns the complete, de‑duplicated owner set that applies to <paramref name="path"/>.
+        /// Callers can post‑process the set depending on platform‑specific approval rules.
+        /// </summary>
+        public IEnumerable<string> Match(string path)
+        {
+            var owners = new HashSet<string>(StringComparer.Ordinal);
+            var normalizedPath = path.IndexOf('\\') >= 0 ? path.Replace('\\', '/') : path;
+
+            foreach (var section in _sections)
+            {
+                if (section.TryMatch(normalizedPath, _platform, out var sectionOwners))
+                {
+                    foreach (var o in sectionOwners)
+                    {
+                        owners.Add(o);
+                    }
+                }
+            }
+
+            return owners;
+        }
+
+        private static List<Section> Parse(IEnumerable<string> lines, Platform platform)
+        {
+            var sections = new List<Section>();
+            var current = Section.CreateUnnamed();
+            sections.Add(current);
+
+            var lineNo = 0;
             foreach (var line in lines)
             {
-                if (string.IsNullOrEmpty(line) || line[0] == '#')
+                lineNo++;
+                var raw = line.TrimEnd();
+                if (raw.Length == 0)
                 {
                     continue;
                 }
 
-                if (line.StartsWith("[") && line.EndsWith("]"))
+                if (TryParseSectionHeader(raw, out var newSection))
                 {
-                    currentSectionName = line.Substring(1, line.Length - 2);
-                    var foundSectionName = sectionsList.FirstOrDefault(s => string.Equals(s, currentSectionName, StringComparison.OrdinalIgnoreCase));
-                    if (foundSectionName is null)
+                    current = newSection;
+                    sections.Add(current);
+                    continue;
+                }
+
+                if (raw[0] == '#')
+                {
+                    // Comment line. GitLab parses owners found inside comments so they appear in MR widget,
+                    // but those owners are not bound to any path pattern, so we ignore them for matching.
+                    continue;
+                }
+
+                var entry = Entry.Parse(raw, platform, lineNo);
+                if (entry is not null)
+                {
+                    current.Add(entry);
+                }
+            }
+
+            // Last‑rule precedence: iterate rules in reverse order at run‑time without additional copies.
+            foreach (var s in sections)
+            {
+                s.Seal();
+            }
+
+            return sections;
+        }
+
+        private static bool TryParseSectionHeader(string raw, [NotNullWhen(true)] out Section? section)
+        {
+            // Accepted forms:
+            //   [Docs]
+            //   ^[Go]
+            //   [Backend][2] @team @another
+            var m = Regex.Match(raw, @"^\s*(\^)?\[(?<name>[^\]]+)\](?:\[(?<cnt>\d+)\])?(?<rest>.*)$");
+            if (!m.Success)
+            {
+                section = null;
+                return false;
+            }
+
+            var required = !m.Groups[1].Success; // ^ prefix => optional section
+            var name = m.Groups["name"].Value.Trim();
+            var approvals = 0;
+            if (m.Groups["cnt"].Success && int.TryParse(m.Groups["cnt"].Value, out var val))
+            {
+                approvals = val;
+            }
+
+            var defaults = OwnerTokenizer.Tokenize(m.Groups["rest"].Value).ToArray();
+            section = new Section(name, required, approvals, defaults);
+            return true;
+        }
+
+        /// <summary>
+        /// Converts a CODEOWNERS ‑style glob into a Regex.
+        /// Supports **, *, ?, /‑rooted, and trailing / semantics.
+        /// </summary>
+        private static Regex CompileGlob(string pattern)
+        {
+            // Escape regex metachars first.
+            var rx = Regex.Escape(pattern);
+
+            // Temporary sentinel for ** that we restore after dealing with single *.
+            rx = rx.Replace("\\*\\*", "§§DOUBLESTAR§§");
+            rx = rx.Replace("\\*", "[^/]*"); // single‑level wildcard
+            rx = rx.Replace("§§DOUBLESTAR§§", ".*"); // multi‑level wildcard
+            rx = rx.Replace("\\?", "."); // single char
+
+            if (pattern.EndsWith("/"))
+            {
+                rx += ".*"; // directory pattern matches everything underneath
+            }
+
+            if (pattern.StartsWith("/"))
+            {
+                // keep the escaped leading slash so paths like "/foo/bar" match
+                rx = "^" + rx;
+            }
+            else
+            {
+                // Allowed anywhere in repo tree; use non‑capturing look‑behind to avoid double counting.
+                rx = "(^|.*/)" + rx;
+            }
+
+            rx += "$";
+            return new Regex(rx, RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        }
+
+#pragma warning disable SA1201
+        public enum Platform
+#pragma warning restore SA1201
+        {
+            GitHub,
+            GitLab
+        }
+
+        private static class OwnerTokenizer
+        {
+            public static IEnumerable<string> Tokenize(string segment)
+            {
+                if (string.IsNullOrWhiteSpace(segment))
+                {
+                    yield break;
+                }
+
+                foreach (var token in segment.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (token.StartsWith("@@") || token.StartsWith("@") || token.Contains("@"))
                     {
-                        sectionsList.Add(currentSectionName);
+                        yield return token;
                     }
-
-                    currentSectionName = foundSectionName ?? currentSectionName;
-                    continue;
                 }
+            }
+        }
 
-                var finalLine = line;
-                var ownersList = new List<string>();
-                var terms = line.Split(new[] { ' ' }, StringSplitOptions.None);
-                for (var i = 0; i < terms.Length; i++)
+        private sealed class Section
+        {
+            private readonly List<Entry> _entries = new();
+            private Entry[]? _cache;
+
+            public Section(string name, bool required, int approvalCount, string[] defaultOwners)
+            {
+                Name = name;
+                Required = required;
+                ApprovalCount = approvalCount;
+                DefaultOwners = defaultOwners.Length == 0 ? [] : defaultOwners;
+            }
+
+            public string Name { get; }
+
+            public bool Required { get; }
+
+            public int ApprovalCount { get; }
+
+            public string[] DefaultOwners { get; }
+
+            public static Section CreateUnnamed() => new(string.Empty, required: true, approvalCount: 0, defaultOwners: []);
+
+            public void Add(Entry entry) => _entries.Add(entry);
+
+            public void Seal() => _cache = _entries.AsEnumerable().Reverse().ToArray();
+
+            public bool TryMatch(string path, Platform platform, out IEnumerable<string> owners)
+            {
+                owners = [];
+                var rules = _cache ?? [];
+
+                foreach (var rule in rules)
                 {
-                    var currentTerm = terms[i];
-                    if (currentTerm.Length == 0)
+                    // GitHub doesn’t support exclusion rules. Keep them parse‑able but ignore when evaluating.
+                    if (rule.IsExclusion && platform == Platform.GitHub)
                     {
                         continue;
                     }
 
-                    // Teams and users handles starts with @
-                    // Emails contains @
-                    if (currentTerm[0] == '@' || currentTerm.Contains("@"))
+                    if (!rule.Match(path))
                     {
-                        ownersList.Add(currentTerm);
-                        var pos = finalLine.IndexOf(currentTerm, StringComparison.Ordinal);
-                        if (pos > 0)
-                        {
-                            finalLine = finalLine.Substring(0, pos) + finalLine.Substring(pos + currentTerm.Length);
-                        }
+                        continue;
                     }
+
+                    if (rule.IsExclusion)
+                    {
+                        // Excluded for this section; stop evaluating this section.
+                        return false;
+                    }
+
+                    owners = rule.Owners.Length > 0 ? rule.Owners : DefaultOwners;
+                    return owners.Any();
                 }
 
-                finalLine = finalLine.Trim();
-                if (finalLine.Length == 0)
+                if (DefaultOwners.Length > 0)
                 {
-                    continue;
+                    owners = DefaultOwners;
+                    return true;
                 }
 
-                entriesList.Add(new Entry(finalLine, ownersList.ToArray(), currentSectionName));
+                return false;
             }
-
-            entriesList.Reverse();
-            _sections = entriesList.GroupBy(i => i.Section).ToArray();
         }
 
-        public Entry? Match(string value)
+        private sealed class Entry
         {
-            var lstEntries = new List<Entry>();
-            foreach (var section in _sections)
+            private readonly Regex _regex;
+
+            private Entry(Regex regex, bool exclusion, string[] owners)
             {
-                foreach (var entry in section)
-                {
-                    var pattern = entry.Pattern;
-                    var finalPattern = pattern;
-
-                    bool includeAnythingBefore;
-                    bool includeAnythingAfter;
-
-                    if (pattern.StartsWith("/"))
-                    {
-                        includeAnythingBefore = false;
-                    }
-                    else
-                    {
-                        if (finalPattern.StartsWith("*"))
-                        {
-                            finalPattern = finalPattern.Substring(1);
-                        }
-
-                        includeAnythingBefore = true;
-                    }
-
-                    if (pattern.EndsWith("/"))
-                    {
-                        includeAnythingAfter = true;
-                    }
-                    else if (pattern.EndsWith("/*"))
-                    {
-                        includeAnythingAfter = true;
-                        finalPattern = finalPattern.Substring(0, finalPattern.Length - 1);
-                    }
-                    else
-                    {
-                        includeAnythingAfter = false;
-                    }
-
-                    if (includeAnythingAfter)
-                    {
-                        var found = includeAnythingBefore ? value.Contains(finalPattern) : value.StartsWith(finalPattern);
-                        if (!found)
-                        {
-                            continue;
-                        }
-
-                        if (!pattern.EndsWith("/*"))
-                        {
-                            lstEntries.Add(entry);
-                            break;
-                        }
-
-                        var patternEnd = value.IndexOf(finalPattern, StringComparison.Ordinal);
-                        if (patternEnd != -1)
-                        {
-                            patternEnd += finalPattern.Length;
-                            var remainingString = value.Substring(patternEnd);
-                            if (remainingString.IndexOf("/", StringComparison.Ordinal) == -1)
-                            {
-                                lstEntries.Add(entry);
-                                break;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (includeAnythingBefore)
-                        {
-                            if (value.EndsWith(finalPattern))
-                            {
-                                lstEntries.Add(entry);
-                                break;
-                            }
-                        }
-                        else if (value == finalPattern)
-                        {
-                            lstEntries.Add(entry);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return lstEntries.Count switch
-            {
-                0 => null,
-                1 => lstEntries[0],
-                _ => lstEntries.Aggregate((a, b) => new Entry($"{a.Pattern} | {b.Pattern}", a.Owners.Concat(b.Owners).ToArray(), $"{a.Section} | {b.Section}"))
-            };
-        }
-
-        internal readonly struct Entry
-        {
-            public readonly string Pattern;
-            public readonly string[] Owners;
-            public readonly string Section;
-
-            public Entry(string pattern, string[] owners, string section)
-            {
-                Pattern = pattern;
+                _regex = regex;
+                IsExclusion = exclusion;
                 Owners = owners;
-                Section = section;
             }
 
-            public string GetOwnersString()
+            public bool IsExclusion { get; }
+
+            public string[] Owners { get; }
+
+            public static Entry? Parse(string raw, Platform platform, int lineNo)
             {
-                if (Owners is null || Owners.Length == 0)
+                // Strip inline comments for GitHub. GitLab treats everything after # as data (inline comments unsupported).
+                var idxHash = raw.IndexOf('#');
+                var effective = idxHash >= 0 && platform == Platform.GitHub ? raw.Substring(0, idxHash).TrimEnd() : raw;
+                if (string.IsNullOrWhiteSpace(effective))
                 {
                     return null;
                 }
 
-                return "[\"" + string.Join("\",\"", Owners) + "\"]";
+                // 2. Tokenise
+                //    * GitHub:   simple whitespace split
+                //    * GitLab:   split on whitespace NOT escaped with back-slash
+                string[] tokens;
+
+                if (platform == Platform.GitLab)
+                {
+                    // Split on space / tab that are **not** escaped:  (?<!\\)[ \t]+
+                    tokens = Regex.Split(effective, @"(?<!\\)[ \t]+", RegexOptions.None, TimeSpan.FromMilliseconds(100))
+                                  .Where(t => t.Length > 0)
+                                   // Undo the escaping:  "\ " → " ",  "\#" → "#",  "\\" → "\"
+                                  .Select(t => Regex.Replace(t, @"\\([ #\\])", "$1"))
+                                  .ToArray();
+                }
+                else
+                {
+                    tokens = effective.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+                }
+
+                if (tokens.Length == 0)
+                {
+                    return null;
+                }
+
+                // 3. Pattern & exclusion
+                var patternToken = tokens[0];
+                var isExclusion = platform == Platform.GitLab && patternToken.StartsWith("!");
+                if (isExclusion)
+                {
+                    patternToken = patternToken.Substring(1, patternToken.Length - 1);
+                }
+
+                // 4. Owners (validate through OwnerTokenizer to drop any bogus tokens)
+                var ownersSegment = tokens.Length > 1 ? string.Join(" ", tokens.Skip(1)) : string.Empty;
+                var owners = OwnerTokenizer.Tokenize(ownersSegment).ToArray();
+
+                // 5. Compile the glob
+                var rx = CompileGlob(patternToken);
+                return new Entry(rx, isExclusion, owners);
             }
+
+            public bool Match(string path) => _regex.IsMatch(path);
         }
     }
 }

--- a/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/Test.cs
+++ b/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/Test.cs
@@ -183,7 +183,12 @@ internal sealed class Test
                 var match = codeOwners.Match("/" + CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(methodSymbol.File, false));
                 if (match is not null)
                 {
-                    tags.CodeOwners = match.Value.GetOwnersString();
+                    var owners = string.Join("\",\"", match);
+                    if (!string.IsNullOrEmpty(owners))
+                    {
+                        tags.CodeOwners = "[\"" + owners + "\"]";
+                    }
+
                 }
             }
         }


### PR DESCRIPTION
Old CodeOwners didn't have support for full github syntax (e.g. `**`). Porting across current Datadog.Trace prod implementation which does.

Just tweaked the couple of places it's used to adapt to the newer interface (gitlab vs github, and just returning enumerable of matches)